### PR TITLE
Add commonName access.

### DIFF
--- a/ASN1Decoder/X509Certificate.swift
+++ b/ASN1Decoder/X509Certificate.swift
@@ -30,12 +30,24 @@ public class X509Certificate: CustomStringConvertible {
     private static let beginPemBlock = "-----BEGIN CERTIFICATE-----"
     private static let endPemBlock   = "-----END CERTIFICATE-----"
 
-    private let OID_KeyUsage = "2.5.29.15"
-    private let OID_ExtendedKeyUsage = "2.5.29.37"
-    private let OID_SubjectAltName = "2.5.29.17"
-    private let OID_IssuerAltName = "2.5.29.18"
-    private let OID_CommonName = kSecOIDCommonName as String
-
+    private let OID_KeyUsage                = "2.5.29.15"
+    private let OID_ExtendedKeyUsage        = "2.5.29.37"
+    private let OID_SubjectAltName          = "2.5.29.17"
+    private let OID_IssuerAltName           = "2.5.29.18"
+    private let OID_CommonName              = kSecOIDCommonName                as String
+    private let OID_DnQualifier             = "2.5.4.46"
+    private let OID_SerialNumber            = kSecOIDSerialNumber              as String
+    private let OID_GivenName               = kSecOIDGivenName                 as String
+    private let OID_Surname                 = kSecOIDSurname                   as String
+    private let OID_OrganizationalUnitName  = kSecOIDOrganizationalUnitName    as String
+    private let OID_OrganizationName        = kSecOIDOrganizationName          as String
+    private let OID_StreetAddress           = kSecOIDStreetAddress             as String
+    private let OID_LocalityName            = kSecOIDLocalityName              as String
+    private let OID_StateOrProvinceName     = kSecOIDStateProvinceName         as String
+    private let OID_CountryName             = kSecOIDCountryName               as String
+    private let OID_eMail                   = kSecOIDEmailAddress              as String
+    
+    
     enum X509BlockPosition : Int {
         case version = 0
         case serialNumber = 1
@@ -164,9 +176,35 @@ public class X509Certificate: CustomStringConvertible {
         return nil
     }
     
-    public var commonName: String? {
-        return self.subject(oid: OID_CommonName)
-    }
+    public var  subjectCommonName:               String? {return self.subject(oid: OID_CommonName)}
+    public var  subjectDnQualifier:              String? {return self.subject(oid: OID_DnQualifier            )}
+    public var  subjectSerialNumber:             String? {return self.subject(oid: OID_SerialNumber    )}
+    public var  subjectGivenName:                String? {return self.subject(oid: OID_GivenName              )}
+    public var  subjectSurname:                  String? {return self.subject(oid: OID_Surname                )}
+    public var  subjectOrganizationalUnitName:   String? {return self.subject(oid: OID_OrganizationalUnitName )}
+    public var  subjectOrganizationName:         String? {return self.subject(oid: OID_OrganizationName       )}
+    public var  subjectStreetAddress:            String? {return self.subject(oid: OID_StreetAddress          )}
+    public var  subjectLocalityName:             String? {return self.subject(oid: OID_LocalityName           )}
+    public var  subjectStateOrProvinceName:      String? {return self.subject(oid: OID_StateOrProvinceName    )}
+    public var  subjectCountryName:              String? {return self.subject(oid: OID_CountryName            )}
+    public var  subjectEMail:                    String? {return self.subject(oid: OID_eMail                  )}
+    
+    
+    public var  issuerCommonName:               String? {return self.issuer(oid: OID_CommonName)}
+    public var  issuerDnQualifier:              String? {return self.issuer(oid: OID_DnQualifier            )}
+    public var  issuerSerialNumber:             String? {return self.issuer(oid: OID_SerialNumber    )}
+    public var  issuerGivenName:                String? {return self.issuer(oid: OID_GivenName              )}
+    public var  issuerSurname:                  String? {return self.issuer(oid: OID_Surname                )}
+    public var  issuerOrganizationalUnitName:   String? {return self.issuer(oid: OID_OrganizationalUnitName )}
+    public var  issuerOrganizationName:         String? {return self.issuer(oid: OID_OrganizationName       )}
+    public var  issuerStreetAddress:            String? {return self.issuer(oid: OID_StreetAddress          )}
+    public var  issuerLocalityName:             String? {return self.issuer(oid: OID_LocalityName           )}
+    public var  issuerStateOrProvinceName:      String? {return self.issuer(oid: OID_StateOrProvinceName    )}
+    public var  issuerCountryName:              String? {return self.issuer(oid: OID_CountryName            )}
+    public var  issuerEMail:                    String? {return self.issuer(oid: OID_eMail                  )}
+    
+    
+    
     
 
     /// Gets the notBefore date from the validity period of the certificate.

--- a/ASN1Decoder/X509Certificate.swift
+++ b/ASN1Decoder/X509Certificate.swift
@@ -34,6 +34,7 @@ public class X509Certificate: CustomStringConvertible {
     private let OID_ExtendedKeyUsage = "2.5.29.37"
     private let OID_SubjectAltName = "2.5.29.17"
     private let OID_IssuerAltName = "2.5.29.18"
+    private let OID_CommonName = kSecOIDCommonName as String
 
     enum X509BlockPosition : Int {
         case version = 0
@@ -162,6 +163,11 @@ public class X509Certificate: CustomStringConvertible {
         }
         return nil
     }
+    
+    public var commonName: String? {
+        return self.subject(oid: OID_CommonName)
+    }
+    
 
     /// Gets the notBefore date from the validity period of the certificate.
     public var notBefore: Date? {

--- a/ASN1DecoderTests/ASN1DecoderTests.swift
+++ b/ASN1DecoderTests/ASN1DecoderTests.swift
@@ -35,7 +35,19 @@ class ASN1DecoderTests: XCTestCase {
         XCTAssertEqual(x509.subjectDistinguishedName,
                        "CN=www.digicert.com, SERIALNUMBER=5299537-0142, OU=SRE, O=\"DigiCert, Inc.\", L=Lehi, ST=Utah, C=US")
         
-        XCTAssertEqual(x509.commonName, "www.digicert.com")
+        XCTAssertEqual(x509.subjectCommonName, "www.digicert.com")
+        XCTAssertEqual(x509.subjectSerialNumber, "5299537-0142")
+        XCTAssertEqual(x509.subjectOrganizationalUnitName, "SRE")
+        XCTAssertEqual(x509.subjectOrganizationName, "DigiCert, Inc.")
+        XCTAssertEqual(x509.subjectLocalityName, "Lehi")
+        XCTAssertEqual(x509.subjectStateOrProvinceName, "Utah")
+        XCTAssertEqual(x509.subjectCountryName, "US")
+        
+        XCTAssertEqual(x509.issuerDistinguishedName,"CN=DigiCert SHA2 Extended Validation Server CA, OU=www.digicert.com, O=DigiCert Inc, C=US")
+        XCTAssertEqual(x509.issuerCommonName, "DigiCert SHA2 Extended Validation Server CA")
+        XCTAssertEqual(x509.issuerOrganizationalUnitName, "www.digicert.com")
+        XCTAssertEqual(x509.issuerOrganizationName, "DigiCert Inc")
+        XCTAssertEqual(x509.issuerCountryName, "US")
     }
 
     func testDecoding() {
@@ -51,7 +63,7 @@ class ASN1DecoderTests: XCTestCase {
                 
                 subject = x509.subjectDistinguishedName ?? ""
                 
-                commonName = x509.commonName ?? ""
+                commonName = x509.subjectCommonName ?? ""
                 
             } catch {
                 print(error)

--- a/ASN1DecoderTests/ASN1DecoderTests.swift
+++ b/ASN1DecoderTests/ASN1DecoderTests.swift
@@ -34,11 +34,14 @@ class ASN1DecoderTests: XCTestCase {
                        "0836BAA2556864172078584638D85C34")
         XCTAssertEqual(x509.subjectDistinguishedName,
                        "CN=www.digicert.com, SERIALNUMBER=5299537-0142, OU=SRE, O=\"DigiCert, Inc.\", L=Lehi, ST=Utah, C=US")
+        
+        XCTAssertEqual(x509.commonName, "www.digicert.com")
     }
 
     func testDecoding() {
         var serialNumber = ""
         var subject = ""
+        var commonName = ""
         
         if let certData = Data(base64Encoded: cert) {
             do {
@@ -48,6 +51,8 @@ class ASN1DecoderTests: XCTestCase {
                 
                 subject = x509.subjectDistinguishedName ?? ""
                 
+                commonName = x509.commonName ?? ""
+                
             } catch {
                 print(error)
             }
@@ -56,6 +61,8 @@ class ASN1DecoderTests: XCTestCase {
         XCTAssertEqual(serialNumber, "59A2F004")
         
         XCTAssertEqual(subject, "CN=John Smith, L=New York, C=US, E=john@mail.com")
+        
+        XCTAssertEqual(commonName, "John Smith")
     }
     
     let cert =


### PR DESCRIPTION
I would like to propose to have a convenience getter for commonName from the DN subject. 
If ok, I would do also the other fields in same manner. Note using the kSecOIDCommonName from Security framework.

dnQualifier
serialNumber
givenName
surname
organizationalUnitName
organizationName
streetAddress
localityName
stateOrProvinceName
countryName
e-mail