### PR TITLE
Support Receipt Validation With Xcode Testing

### DIFF
--- a/ASN1Decoder/ASN1Object.swift
+++ b/ASN1Decoder/ASN1Object.swift
@@ -71,6 +71,20 @@ public class ASN1Object: CustomStringConvertible {
         return printAsn1()
     }
 
+    public func asString() -> String? {
+        if let string = value as? String {
+            return string
+        }
+        
+        for item in sub ?? [] {
+            if let string = item.asString() {
+                return string
+            }
+        }
+        
+        return nil
+    }
+    
     fileprivate func printAsn1(insets: String = "") -> String {
         var output = insets
         output.append(identifier?.description.uppercased() ?? "")

--- a/ASN1Decoder/ASN1Object.swift
+++ b/ASN1Decoder/ASN1Object.swift
@@ -71,13 +71,13 @@ public class ASN1Object: CustomStringConvertible {
         return printAsn1()
     }
 
-    public func asString() -> String? {
+    public var asString: String? {
         if let string = value as? String {
             return string
         }
         
         for item in sub ?? [] {
-            if let string = item.asString() {
+            if let string = item.asString {
                 return string
             }
         }

--- a/ASN1Decoder/PKCS7_AppleReceipt.swift
+++ b/ASN1Decoder/PKCS7_AppleReceipt.swift
@@ -80,17 +80,13 @@ extension PKCS7 {
         guard var receiptBlock = block.parent?.sub?.last?.sub(0)?.sub(0) else { return nil }
         var receiptInfo = ReceiptInfo()
 
-        if let first = receiptBlock.sub(0), let flag = first.sub(0)?.sub(2)?.sub(0)?.value as? String, flag == "Xcode" {
-            receiptBlock = first
+        if receiptBlock.asString == "Xcode" {
+            receiptBlock = receiptBlock.sub(0)!
         }
         
         for item in receiptBlock.sub ?? [] {
-            var fieldType = (item.sub(0)?.value as? Data)?.toIntValue() ?? 0
-//            if let flag = item.sub(0)!.sub(2)?.sub(0)?.value as? String, flag == "Xcode" {
-//                fieldType = 2
-//            }
-            
-            let fieldValueString = item.sub(2)?.asString()
+            let fieldType = (item.sub(0)?.value as? Data)?.toIntValue() ?? 0
+            let fieldValueString = item.sub(2)?.asString
             switch fieldType {
             case 2:
                 receiptInfo.bundleIdentifier = fieldValueString

--- a/ASN1Decoder/PKCS7_AppleReceipt.swift
+++ b/ASN1Decoder/PKCS7_AppleReceipt.swift
@@ -77,12 +77,20 @@ extension PKCS7 {
 
     public func receipt() -> ReceiptInfo? {
         guard let block = mainBlock.findOid(.pkcs7data) else { return nil }
-        guard let receiptBlock = block.parent?.sub?.last?.sub(0)?.sub(0) else { return nil }
+        guard var receiptBlock = block.parent?.sub?.last?.sub(0)?.sub(0) else { return nil }
         var receiptInfo = ReceiptInfo()
 
+        if let first = receiptBlock.sub(0), let flag = first.sub(0)?.sub(2)?.sub(0)?.value as? String, flag == "Xcode" {
+            receiptBlock = first
+        }
+        
         for item in receiptBlock.sub ?? [] {
-            let fieldType = (item.sub(0)?.value as? Data)?.toIntValue() ?? 0
-            let fieldValueString = item.sub(2)?.sub?.first?.value as? String
+            var fieldType = (item.sub(0)?.value as? Data)?.toIntValue() ?? 0
+//            if let flag = item.sub(0)!.sub(2)?.sub(0)?.value as? String, flag == "Xcode" {
+//                fieldType = 2
+//            }
+            
+            let fieldValueString = item.sub(2)?.asString()
             switch fieldType {
             case 2:
                 receiptInfo.bundleIdentifier = fieldValueString


### PR DESCRIPTION
Xcode 12 introduced testing of In-App purchases locally without the server being involved (https://developer.apple.com/videos/play/wwdc2020/10659/).

They deliver the receipt in the normal place, but it seems to have a slightly different structure, where it is embedded one level deeper.

This patch allows it to be decoded.