### PR TITLE
Expose Raw Public Key Data

### DIFF
--- a/ASN1Decoder/X509PublicKey.swift
+++ b/ASN1Decoder/X509PublicKey.swift
@@ -43,11 +43,15 @@ public class X509PublicKey {
         return pkBlock.sub(0)?.sub(1)?.value as? String
     }
 
+    public var rawKey: Data? {
+        return pkBlock.sub(1)?.value as? Data
+    }
+
     public var key: Data? {
         guard
             let algOid = algOid,
             let oid = OID(rawValue: algOid),
-            let keyData = pkBlock.sub(1)?.value as? Data else {
+            let keyData = rawKey else {
                 return nil
         }
 


### PR DESCRIPTION
We are using ASN1Decoder to parse App Store receipts. As we want to switch from OpenSSL to Security.framework for signature verification, we need access to the raw RSA key data.  

We are using `SecKeyCreateWithData` to instantiate our `SecKey`. This expects the key in DER format with header. We are prepending the header on the call site, but we do need access to the key data. This PR exposes the raw key data as property. 

If this PR gets merged, a DER key - compatible with `SecKeyCreateWithData` - can be obtained via:

```swift
private extension X509PublicKey {

    var rawDERKey: Data? {
        guard let rawKey = self.rawKey else { return nil }

        let header: [UInt8] = [0x30, 0x82, 0x01, 0x22,
                               0x30, 0x0D,
                               0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,
                               0x05, 0x00,
                               0x03, 0x82, 0x01, 0x0F, 0x00]
        var rawDERKey = Data(header)
        rawDERKey.append(rawKey)
        return rawDERKey
    }
}
```


**Update**  
An unrelated small problem I ran into was:  
Git tags in this repo sometimes lack the `minor` version. (e.g. `1.5` instead of `1.5.0`). 
The Swift Package manager seems to rely on the minor version and exits with `Invalid semantic version string '1.5'` when using the following dependency in a package:
```swift
.package(url: "https://github.com/filom/ASN1Decoder", from: "1.5")
```