### PR TITLE
Exposes sub and parent properties on ASN1Object

### DIFF
--- a/ASN1Decoder/ASN1Decoder.swift
+++ b/ASN1Decoder/ASN1Decoder.swift
@@ -199,7 +199,7 @@ enum ASN1Error: Error {
 }
 
 extension Data {
-    func toIntValue() -> UInt64? {
+    public func toIntValue() -> UInt64? {
         if self.count > 8 { // check if suitable for UInt64
             return nil
         }

--- a/ASN1Decoder/ASN1Object.swift
+++ b/ASN1Decoder/ASN1Object.swift
@@ -33,9 +33,9 @@ public class ASN1Object: CustomStringConvertible {
 
     public var identifier: ASN1Identifier?
 
-    public var sub: [ASN1Object]?
+    public internal(set) var sub: [ASN1Object]?
 
-    public weak var parent: ASN1Object?
+    public internal(set) weak var parent: ASN1Object?
 
     public func sub(_ index: Int) -> ASN1Object? {
         if let sub = self.sub, index >= 0, index < sub.count {

--- a/ASN1Decoder/ASN1Object.swift
+++ b/ASN1Decoder/ASN1Object.swift
@@ -33,9 +33,9 @@ public class ASN1Object: CustomStringConvertible {
 
     public var identifier: ASN1Identifier?
 
-    var sub: [ASN1Object]?
+    public var sub: [ASN1Object]?
 
-    weak var parent: ASN1Object?
+    public weak var parent: ASN1Object?
 
     public func sub(_ index: Int) -> ASN1Object? {
         if let sub = self.sub, index >= 0, index < sub.count {


### PR DESCRIPTION
Additional to the mainBlock of pkcs7 we also need the flexibility to have read access to those two properties.