### PR TITLE
fixed issue sans ips not returned by x509 extension class

### DIFF
--- a/ASN1Decoder.podspec
+++ b/ASN1Decoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ASN1Decoder"
-  s.version      = "1.9.0"
+  s.version      = "1.9.1"
   s.summary      = "ASN1 DER Decoder for X.509 certificate"
   s.description  = "ASN1 DER Decoder to parse X.509 certificate"
   s.homepage     = "https://github.com/filom/ASN1Decoder"

--- a/ASN1Decoder/X509ExtensionAltName.swift
+++ b/ASN1Decoder/X509ExtensionAltName.swift
@@ -70,6 +70,9 @@ extension X509Extension {
         case 7:
             if let ip = item.value as? Data {
                 return ip.map({ "\($0)" }).joined(separator: ".")
+            } else if let ipString = item.value as? String {
+                let ipData = Data(ipString.utf8)
+                return ipData.map({ "\($0)" }).joined(separator: ".")
             }
         case 8:
             if let value = item.value as? String, var data = value.data(using: .utf8) {

--- a/ASN1Decoder/X509ExtensionAltName.swift
+++ b/ASN1Decoder/X509ExtensionAltName.swift
@@ -68,12 +68,11 @@ extension X509Extension {
                 return ASN1DistinguishedNameFormatter.string(from: sequence)
             }
         case 7:
-            if let ip = item.value as? Data {
-                return ip.map({ "\($0)" }).joined(separator: ".")
-            } else if let ipString = item.value as? String {
-                let ipData = Data(ipString.utf8)
-                return ipData.map({ "\($0)" }).joined(separator: ".")
+            if let ip = item.rawValue {
+                let separator = ip.count == 4 ? "." : ":"
+                return ip.map({ "\($0)" }).joined(separator: separator)
             }
+
         case 8:
             if let value = item.value as? String, var data = value.data(using: .utf8) {
                 let oid = ASN1DERDecoder.decodeOid(contentData: &data)


### PR DESCRIPTION
I generated a certificate in hashicorp-vault, along with 2 SAN DNSs and 2 SAN IPs, the subjectAlternativeNames field on the X509Certificate class only returned the 2 DNSs while the 2 IPs were lost. For e.g. when I enter the sample IP "124.0.0.2", on line 71 of X509ExtensionAltName the variable item.value contains |\0\0\u{2} in Xcode debugger, which is a string represents binary data. 

The as? Data cast will only succeed if item.value is already a Data object. If item.value is a String, the cast will fail, even if the string represents binary data.

since item.value is a String that represents binary data, I had to convert it to Data before extracting the IP address, i.e.:
if let ipString = item.value as? String {
   let ipData = Data(ipString.utf8)
   return ipData.map({ "\($0)" }).joined(separator: ".")
}

with that fix, X509Certificate!.subjectAlternativeNames finally returns my SAN IPs as well as the SAN DNSs.